### PR TITLE
Fixed incomming message receive misses

### DIFF
--- a/ipc.go
+++ b/ipc.go
@@ -128,8 +128,8 @@ func (ipc IPC) Start() {
 
 		}
 	}()
+	reader := bufio.NewReader(os.Stdin)
 	for {
-		reader := bufio.NewReader(os.Stdin)
 		text, err := reader.ReadString('\n')
 		if err != nil {
 			log.Println(err)


### PR DESCRIPTION
Thank you for your handy library.

I noticed that sometimes this software misses to receive some incoming message.

After some investigation,  I came to realize that the `bufio.Reader`, which created each time to read from `stdout`,
having a problem that it potentially reads bunch of data at once but we always uses just one line.

When we create another `Reader` next time,
we misses some lines of buffered messages which owned by a previous reader instance.

I moved the line to create `Reader` into outside of for-statements so that all the incoming message should be handled.